### PR TITLE
fix: Laravel 10.x support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,12 @@ notifications:
         on_failure: always
 
 php:
-  - 7.0
-  - 7.1
-  - 7.2
+  - 8.0
+  - 8.1
+  - 8.2
 
 env:
-  - LARAVEL_VERSION=5.5.*
+  - LARAVEL_VERSION=10.0.*
 
 before_install:
   - travis_retry composer self-update --stable -n

--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,11 @@
   ],
   "require": {
     "php": "^8.0",
-    "illuminate/support": "^8.5|^9.0",
+    "illuminate/support": "^8.5|^9.0|^10.0",
     "spatie/laravel-webhook-server": "^3.1"
   },
   "require-dev": {
-    "orchestra/testbench": "^4.0|^5.0",
+    "orchestra/testbench": "^4.0|^5.0|^6.0|^7.0|^8.0",
     "phpunit/phpunit": "^9.3.0"
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,13 @@
     }
   ],
   "require": {
-    "php": "^8.0",
-    "illuminate/support": "^8.5|^9.0|^10.0",
+    "php": "^8.1",
+    "illuminate/support": "^9.0|^10.0|^11.0",
     "spatie/laravel-webhook-server": "^3.1"
   },
   "require-dev": {
-    "orchestra/testbench": "^4.0|^5.0|^6.0|^7.0|^8.0",
-    "phpunit/phpunit": "^9.3.0"
+    "orchestra/testbench": "^7.0|^8.0|^9.0",
+    "phpunit/phpunit": "^9.3.0|^10.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
- Have changed the composer dependencies to allow to support `Laravel 10.x` , by changing version requirements for `illuminate/support` and `orchestra/testbench`.
- Have changed the Travis YAML to support more recent supported php versions `8.0/8.1/8.2`, and Laravel to be `10.0.*` as `Laravel 9.x` support ends on 6th Feb 2024